### PR TITLE
Use trait Read instead of BufReader<File> +  bug fixes

### DIFF
--- a/src/elements.rs
+++ b/src/elements.rs
@@ -4,13 +4,13 @@ pub type Coordinate = f64;
 pub type Id = i64;
 pub type Role = String;
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 pub struct Tag {
     pub key: String,
     pub val: String,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Copy, Clone)]
 pub struct Bounds {
     pub minlat: Coordinate,
     pub minlon: Coordinate,
@@ -18,7 +18,7 @@ pub struct Bounds {
     pub maxlon: Coordinate,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 pub struct Node {
     pub id: Id,
     pub lat: Coordinate,
@@ -26,7 +26,7 @@ pub struct Node {
     pub tags: Vec<Tag>,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 pub struct Way {
     pub id: Id,
     pub tags: Vec<Tag>,
@@ -39,28 +39,28 @@ impl Way {
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 pub struct Relation {
     pub id: Id,
     pub members: Vec<Member>,
     pub tags: Vec<Tag>,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 pub enum Member {
     Node(UnresolvedReference, Role),
     Way(UnresolvedReference, Role),
     Relation(UnresolvedReference, Role),
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Copy, Clone)]
 pub enum UnresolvedReference {
     Node(Id),
     Way(Id),
     Relation(Id),
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 pub enum Reference<'a> {
     Node(&'a Node),
     Way(&'a Way),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@ use std::str::FromStr;
 use xml::reader::{EventReader, XmlEvent};
 use xml::attribute::OwnedAttribute;
 
-mod error;
+pub mod error;
 use error::{Error, ErrorReason};
 
 mod elements;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,6 @@
 extern crate xml;
 
-use std::fs::File;
-use std::io::BufReader;
+use std::io::prelude::*;
 use std::str::FromStr;
 
 use xml::reader::{EventReader, XmlEvent};
@@ -33,11 +32,11 @@ impl OSM {
         }
     }
 
-    pub fn parse(file: File) -> Result<OSM, Error> {
+    pub fn parse<R: Read>(source: R) -> Result<OSM, Error> {
+        
         let mut osm = OSM::empty();
 
-        let reader = BufReader::new(file);
-        let mut parser = EventReader::new(reader);
+        let mut parser = EventReader::new(source);
 
         loop {
             match parse_element_data(&mut parser) {
@@ -147,7 +146,7 @@ impl FromStr for ElementType {
     }
 }
 
-fn parse_element_data(parser: &mut EventReader<BufReader<File>>) -> Result<ElementData, Error> {
+fn parse_element_data<R: Read>(parser: &mut EventReader<R>) -> Result<ElementData, Error> {
     let element = try!(parser.next());
     match element {
         XmlEvent::EndDocument => Ok(ElementData::EndOfDocument),
@@ -166,7 +165,7 @@ fn parse_element_data(parser: &mut EventReader<BufReader<File>>) -> Result<Eleme
     }
 }
 
-fn parse_relation(parser: &mut EventReader<BufReader<File>>,
+fn parse_relation<R: Read>(parser: &mut EventReader<R>,
                   attrs: &Vec<OwnedAttribute>)
                   -> Result<ElementData, Error> {
     let id = try!(find_attribute("id", attrs).map_err(Error::MalformedRelation));
@@ -229,7 +228,7 @@ fn parse_relation(parser: &mut EventReader<BufReader<File>>,
     }
 }
 
-fn parse_way(parser: &mut EventReader<BufReader<File>>,
+fn parse_way<R: Read>(parser: &mut EventReader<R>,
              attrs: &Vec<OwnedAttribute>)
              -> Result<ElementData, Error> {
     let id = try!(find_attribute("id", attrs).map_err(Error::MalformedWay));
@@ -273,7 +272,7 @@ fn parse_way(parser: &mut EventReader<BufReader<File>>,
 
 }
 
-fn parse_node(parser: &mut EventReader<BufReader<File>>,
+fn parse_node<R: Read>(parser: &mut EventReader<R>,
               attrs: &Vec<OwnedAttribute>)
               -> Result<ElementData, Error> {
     let id = try!(find_attribute("id", attrs).map_err(Error::MalformedNode));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,10 @@
+#![deny(missing_copy_implementations,
+        trivial_numeric_casts,
+        trivial_casts,
+        unused_extern_crates,
+        unused_import_braces,
+        unused_qualifications)]
+
 extern crate xml;
 
 use std::io::prelude::*;
@@ -330,7 +337,7 @@ fn parse_bounds(attrs: &Vec<OwnedAttribute>) -> Result<ElementData, Error> {
 }
 
 fn find_attribute<T>(name: &str, attrs: &Vec<OwnedAttribute>) -> Result<T, ErrorReason>
-    where ErrorReason: std::convert::From<<T as std::str::FromStr>::Err>,
+    where ErrorReason: From<<T as std::str::FromStr>::Err>,
           T: FromStr
 {
     let val_raw = try!(find_attribute_uncasted(name, attrs));


### PR DESCRIPTION
This PR allows reading osm xml files from arbitrary sources (for example, network streams) and not just files. Gives more control to the user of the library. 

There may be a performance problem now: `parse()` has hidden the `BufReader<File>`. So now, the File is essentially directly passed into the function (because `File` implements `Read`, this is perfectly valid).
On the other hand, it's not a good idea to hide these things from library users, so it may be advisable to tell people in the next revision of the library to pass a BufReader<File> into the `parse()` function.

Unit tests run fine, haven't added any.