### PR TITLE
Switch main data structures from Vec to  FNV HashMap

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "osm-xml"
-version = "0.5.1"
+version = "0.6.1"
 authors = ["Iivari Äikäs <iivari.aikas@gmail.com>"]
 
 description = "OSM xml parser for Rust"
@@ -16,3 +16,4 @@ license = "MIT"
 
 [dependencies]
 xml-rs = "0.3"
+fnv = "1.0.6"

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ fn main() {
     let doc = osm::OSM::parse(f).unwrap();
     let rel_info = relation_reference_statistics(&doc);
     let way_info = way_reference_statistics(&doc);
-    let poly_count = doc.ways.iter().fold(0, |acc, way| {
+    let poly_count = doc.ways.values().fold(0, |acc, way| {
         if way.is_polygon() {
             return acc + 1
         }
@@ -64,7 +64,7 @@ fn main() {
 }
 
 fn relation_reference_statistics(doc: &osm::OSM) -> (usize, usize, usize) {
-    doc.relations.iter()
+    doc.relations.values()
         .flat_map(|relation| relation.members.iter())
         .fold((0, 0, 0), |acc, member| {
             let el_ref = match *member {
@@ -83,7 +83,7 @@ fn relation_reference_statistics(doc: &osm::OSM) -> (usize, usize, usize) {
 }
 
 fn way_reference_statistics(doc: &osm::OSM) -> (usize, usize) {
-    doc.ways.iter()
+    doc.ways.values()
         .flat_map(|way| way.nodes.iter())
         .fold((0, 0), |acc, node| {
             match doc.resolve_reference(&node) {
@@ -96,13 +96,13 @@ fn way_reference_statistics(doc: &osm::OSM) -> (usize, usize) {
 }
 
 fn tag_count(doc: &osm::OSM) -> usize {
-    let node_tag_count = doc.nodes.iter()
+    let node_tag_count = doc.nodes.values()
         .map(|node| node.tags.len())
         .fold(0, |acc, c| acc + c);
-    let way_tag_count = doc.ways.iter()
+    let way_tag_count = doc.ways.values()
         .map(|way| way.tags.len())
         .fold(0, |acc, c| acc + c);
-    let relation_tag_count = doc.relations.iter()
+    let relation_tag_count = doc.relations.values()
         .map(|relation| relation.tags.len())
         .fold(0, |acc, c| acc + c);
 

--- a/tests/parsing.rs
+++ b/tests/parsing.rs
@@ -46,18 +46,18 @@ fn node_existence() {
 fn node_ids() {
     let f = File::open("./tests/test_data/two_nodes.osm").unwrap();
     let osm = OSM::parse(f).unwrap();
-    assert_eq!(osm.nodes[0].id, 25496583);
-    assert_eq!(osm.nodes[1].id, 25496584);
+    assert_eq!(osm.nodes[&25496583].id, 25496583);
+    assert_eq!(osm.nodes[&25496584].id, 25496584);
 }
 
 #[test]
 fn node_coordinates() {
     let f = File::open("./tests/test_data/two_nodes.osm").unwrap();
     let osm = OSM::parse(f).unwrap();
-    assert_eq!(osm.nodes[0].lat, 51.5173639);
-    assert_eq!(osm.nodes[0].lon, -0.140043);
-    assert_eq!(osm.nodes[1].lat, 51.5173640);
-    assert_eq!(osm.nodes[1].lon, -0.140041);
+    assert_eq!(osm.nodes[&25496583].lat, 51.5173639);
+    assert_eq!(osm.nodes[&25496583].lon, -0.140043);
+    assert_eq!(osm.nodes[&25496584].lat, 51.5173640);
+    assert_eq!(osm.nodes[&25496584].lon, -0.140041);
 }
 
 #[test]
@@ -66,11 +66,11 @@ fn skip_only_malformed_nodes() {
     let osm = OSM::parse(f).unwrap();
     assert_eq!(osm.nodes.len(), 3);
 
-    let node = osm.nodes.iter().find(|n| n.id == 25496585);
+    let node = osm.nodes.values().find(|n| n.id == 25496585);
     assert!(node.is_some());
-    let node = osm.nodes.iter().find(|n| n.id == 25496586);
+    let node = osm.nodes.values().find(|n| n.id == 25496586);
     assert!(node.is_some());
-    let node = osm.nodes.iter().find(|n| n.id == 25496587);
+    let node = osm.nodes.values().find(|n| n.id == 25496587);
     assert!(node.is_some());
 }
 
@@ -78,33 +78,33 @@ fn skip_only_malformed_nodes() {
 fn skip_malformed_node_with_child_node() {
     let f = File::open("./tests/test_data/invalid_nodes.osm").unwrap();
     let osm = OSM::parse(f).unwrap();
-    assert_eq!(osm.nodes.iter().find(|n| n.id == 25496583), None);
-    assert_eq!(osm.nodes.iter().find(|n| n.id == 25496584), None);
+    assert_eq!(osm.nodes.values().find(|n| n.id == 25496583), None);
+    assert_eq!(osm.nodes.values().find(|n| n.id == 25496584), None);
 }
 
 #[test]
 fn skip_malformed_node_with_child_way() {
     let f = File::open("./tests/test_data/invalid_nodes.osm").unwrap();
     let osm = OSM::parse(f).unwrap();
-    assert_eq!(osm.nodes.iter().find(|n| n.id == 25496588), None);
+    assert_eq!(osm.nodes.values().find(|n| n.id == 25496588), None);
 }
 
 #[test]
 fn node_tag_existence() {
     let f = File::open("./tests/test_data/two_nodes.osm").unwrap();
     let osm = OSM::parse(f).unwrap();
-    assert_eq!(osm.nodes[0].tags.len(), 2);
-    assert_eq!(osm.nodes[1].tags.len(), 0);
+    assert_eq!(osm.nodes[&25496583].tags.len(), 2);
+    assert_eq!(osm.nodes[&25496584].tags.len(), 0);
 }
 
 #[test]
 fn node_tag_contents() {
     let f = File::open("./tests/test_data/two_nodes.osm").unwrap();
     let osm = OSM::parse(f).unwrap();
-    assert_eq!(osm.nodes[0].tags[0].key, "highway".to_string());
-    assert_eq!(osm.nodes[0].tags[0].val, "traffic_signals".to_string());
-    assert_eq!(osm.nodes[0].tags[1].key, "test_key".to_string());
-    assert_eq!(osm.nodes[0].tags[1].val, "test_value".to_string());
+    assert_eq!(osm.nodes[&25496583].tags[0].key, "highway".to_string());
+    assert_eq!(osm.nodes[&25496583].tags[0].val, "traffic_signals".to_string());
+    assert_eq!(osm.nodes[&25496583].tags[1].key, "test_key".to_string());
+    assert_eq!(osm.nodes[&25496583].tags[1].val, "test_value".to_string());
 }
 
 #[test]
@@ -112,7 +112,7 @@ fn skip_malformed_node_tags() {
     let f = File::open("./tests/test_data/invalid_nodes.osm").unwrap();
     let osm = OSM::parse(f).unwrap();
 
-    let node = osm.nodes.iter().find(|n| n.id == 25496587);
+    let node = osm.nodes.values().find(|n| n.id == 25496587);
     assert_eq!(node.unwrap().tags.len(), 1);
 }
 
@@ -122,8 +122,8 @@ fn way_existence() {
     let osm = OSM::parse(f).unwrap();
 
     assert_eq!(osm.ways.len(), 2);
-    assert_eq!(osm.ways[0].id, 4253174);
-    assert_eq!(osm.ways[1].id, 4253123);
+    assert_eq!(osm.ways[&4253174].id, 4253174);
+    assert_eq!(osm.ways[&4253123].id, 4253123);
 }
 
 #[test]
@@ -131,29 +131,29 @@ fn way_tags() {
     let f = File::open("./tests/test_data/way.osm").unwrap();
     let osm = OSM::parse(f).unwrap();
 
-    assert_eq!(osm.ways[0].tags.len(), 11);
-    assert_eq!(osm.ways[0].tags[0].key, "highway".to_string());
-    assert_eq!(osm.ways[0].tags[0].val, "residential".to_string());
-    assert_eq!(osm.ways[0].tags[1].key, "lanes".to_string());
-    assert_eq!(osm.ways[0].tags[1].val, "1".to_string());
-    assert_eq!(osm.ways[0].tags[2].key, "lit".to_string());
-    assert_eq!(osm.ways[0].tags[2].val, "yes".to_string());
-    assert_eq!(osm.ways[0].tags[3].key, "maxspeed".to_string());
-    assert_eq!(osm.ways[0].tags[3].val, "30".to_string());
-    assert_eq!(osm.ways[0].tags[4].key, "name".to_string());
-    assert_eq!(osm.ways[0].tags[4].val, "Maurinkatu".to_string());
-    assert_eq!(osm.ways[0].tags[5].key, "name:fi".to_string());
-    assert_eq!(osm.ways[0].tags[5].val, "Maurinkatu".to_string());
-    assert_eq!(osm.ways[0].tags[6].key, "name:sv".to_string());
-    assert_eq!(osm.ways[0].tags[6].val, "Mauritzgatan".to_string());
-    assert_eq!(osm.ways[0].tags[7].key, "old_name:fi".to_string());
-    assert_eq!(osm.ways[0].tags[7].val, "Mauritsinkatu".to_string());
-    assert_eq!(osm.ways[0].tags[8].key, "snowplowing".to_string());
-    assert_eq!(osm.ways[0].tags[8].val, "yes".to_string());
-    assert_eq!(osm.ways[0].tags[9].key, "start_date".to_string());
-    assert_eq!(osm.ways[0].tags[9].val, "before 1815".to_string());
-    assert_eq!(osm.ways[0].tags[10].key, "surface".to_string());
-    assert_eq!(osm.ways[0].tags[10].val, "paved".to_string());
+    assert_eq!(osm.ways[&4253174].tags.len(), 11);
+    assert_eq!(osm.ways[&4253174].tags[0].key, "highway".to_string());
+    assert_eq!(osm.ways[&4253174].tags[0].val, "residential".to_string());
+    assert_eq!(osm.ways[&4253174].tags[1].key, "lanes".to_string());
+    assert_eq!(osm.ways[&4253174].tags[1].val, "1".to_string());
+    assert_eq!(osm.ways[&4253174].tags[2].key, "lit".to_string());
+    assert_eq!(osm.ways[&4253174].tags[2].val, "yes".to_string());
+    assert_eq!(osm.ways[&4253174].tags[3].key, "maxspeed".to_string());
+    assert_eq!(osm.ways[&4253174].tags[3].val, "30".to_string());
+    assert_eq!(osm.ways[&4253174].tags[4].key, "name".to_string());
+    assert_eq!(osm.ways[&4253174].tags[4].val, "Maurinkatu".to_string());
+    assert_eq!(osm.ways[&4253174].tags[5].key, "name:fi".to_string());
+    assert_eq!(osm.ways[&4253174].tags[5].val, "Maurinkatu".to_string());
+    assert_eq!(osm.ways[&4253174].tags[6].key, "name:sv".to_string());
+    assert_eq!(osm.ways[&4253174].tags[6].val, "Mauritzgatan".to_string());
+    assert_eq!(osm.ways[&4253174].tags[7].key, "old_name:fi".to_string());
+    assert_eq!(osm.ways[&4253174].tags[7].val, "Mauritsinkatu".to_string());
+    assert_eq!(osm.ways[&4253174].tags[8].key, "snowplowing".to_string());
+    assert_eq!(osm.ways[&4253174].tags[8].val, "yes".to_string());
+    assert_eq!(osm.ways[&4253174].tags[9].key, "start_date".to_string());
+    assert_eq!(osm.ways[&4253174].tags[9].val, "before 1815".to_string());
+    assert_eq!(osm.ways[&4253174].tags[10].key, "surface".to_string());
+    assert_eq!(osm.ways[&4253174].tags[10].val, "paved".to_string());
 }
 
 #[test]
@@ -161,36 +161,36 @@ fn way_node_references() {
     let f = File::open("./tests/test_data/way.osm").unwrap();
     let osm = OSM::parse(f).unwrap();
 
-    let nodes = &osm.ways[0].nodes;
+    let nodes = &osm.ways[&4253174].nodes;
     assert_eq!(nodes.len(), 7);
 
     match nodes[0] {
         osm::UnresolvedReference::Node(id) => assert_eq!(id, 1375815878),
-        _ => assert!(false, "Way reference was not reference to Node!")
+        _ => panic!("Way reference was not reference to Node!")
     }
     match nodes[1] {
         osm::UnresolvedReference::Node(id) => assert_eq!(id, 391448656),
-        _ => assert!(false, "Way reference was not reference to Node!")
+        _ => panic!("Way reference was not reference to Node!")
     }
     match nodes[2] {
         osm::UnresolvedReference::Node(id) => assert_eq!(id, 340886677),
-        _ => assert!(false, "Way reference was not reference to Node!")
+        _ => panic!("Way reference was not reference to Node!")
     }
     match nodes[3] {
         osm::UnresolvedReference::Node(id) => assert_eq!(id, 1651393269),
-        _ => assert!(false, "Way reference was not reference to Node!")
+        _ => panic!("Way reference was not reference to Node!")
     }
     match nodes[4] {
         osm::UnresolvedReference::Node(id) => assert_eq!(id, 471408613),
-        _ => assert!(false, "Way reference was not reference to Node!")
+        _ => panic!("Way reference was not reference to Node!")
     }
     match nodes[5] {
         osm::UnresolvedReference::Node(id) => assert_eq!(id, 25470395),
-        _ => assert!(false, "Way reference was not reference to Node!")
+        _ => panic!("Way reference was not reference to Node!")
     }
     match nodes[6] {
         osm::UnresolvedReference::Node(id) => assert_eq!(id, 1376857625),
-        _ => assert!(false, "Way reference was not reference to Node!")
+        _ => panic!("Way reference was not reference to Node!")
     }
 }
 
@@ -200,12 +200,12 @@ fn relation_existence() {
     let osm = OSM::parse(f).unwrap();
 
     assert_eq!(osm.relations.len(), 6);
-    assert_eq!(osm.relations[0].id, 77994);
-    assert_eq!(osm.relations[1].id, 1688359);
-    assert_eq!(osm.relations[2].id, 375952);
-    assert_eq!(osm.relations[3].id, 375951);
-    assert_eq!(osm.relations[4].id, 155054);
-    assert_eq!(osm.relations[5].id, 987654);
+    assert_eq!(osm.relations[&77994].id, 77994);
+    assert_eq!(osm.relations[&1688359].id, 1688359);
+    assert_eq!(osm.relations[&375952].id, 375952);
+    assert_eq!(osm.relations[&375951].id, 375951);
+    assert_eq!(osm.relations[&155054].id, 155054);
+    assert_eq!(osm.relations[&987654].id, 987654);
 }
 
 #[test]
@@ -213,7 +213,7 @@ fn relation_tags() {
     let f = File::open("./tests/test_data/relations.osm").unwrap();
     let osm = OSM::parse(f).unwrap();
 
-    let tags = &osm.relations[0].tags;
+    let tags = &osm.relations[&77994].tags;
     assert_eq!(tags[0].key, "type".to_string());
     assert_eq!(tags[0].val, "surveillance".to_string());
 }
@@ -223,26 +223,26 @@ fn relation_node_members() {
     let f = File::open("./tests/test_data/relations.osm").unwrap();
     let osm = OSM::parse(f).unwrap();
 
-    match osm.relations[0].members[0] {
+    match osm.relations[&77994].members[0] {
         osm::Member::Node(ref ref_id, ref role) => {
             match *ref_id {
                 osm::UnresolvedReference::Node(id) => assert_eq!(id, 345579224),
-                _ => assert!(false, "Member reference was wrong type!")
+                _ => panic!("Member reference was wrong type!")
             }
             assert_eq!(*role, "camera".to_string());
         },
-        _ => assert!(false, "Member was not expected Member-variant")
+        _ => panic!("Member was not expected Member-variant")
     }
 
-    match osm.relations[0].members[1] {
+    match osm.relations[&77994].members[1] {
         osm::Member::Node(ref ref_id, ref role) => {
             match *ref_id {
                 osm::UnresolvedReference::Node(id) => assert_eq!(id, 345579225),
-                _ => assert!(false, "Member reference was wrong type!")
+                _ => panic!("Member reference was wrong type!")
             }
             assert_eq!(*role, "visible".to_string());
         },
-        _ => assert!(false, "Member was not expected Member-variant")
+        _ => panic!("Member was not expected Member-variant")
     }
 }
 
@@ -251,26 +251,26 @@ fn relation_way_members() {
     let f = File::open("./tests/test_data/relations.osm").unwrap();
     let osm = OSM::parse(f).unwrap();
 
-    match osm.relations[1].members[0] {
+    match osm.relations[&1688359].members[0] {
         osm::Member::Way(ref ref_id, ref role) => {
             match *ref_id {
                 osm::UnresolvedReference::Way(id) => assert_eq!(id, 123365172),
-                _ => assert!(false, "Member reference was wrong type!")
+                _ => panic!("Member reference was wrong type!")
             }
             assert_eq!(*role, "outer".to_string());
         },
-        _ => assert!(false, "Member was not expected Member-variant")
+        _ => panic!("Member was not expected Member-variant")
     }
 
-    match osm.relations[1].members[1] {
+    match osm.relations[&1688359].members[1] {
         osm::Member::Way(ref ref_id, ref role) => {
             match *ref_id {
                 osm::UnresolvedReference::Way(id) => assert_eq!(id, 22147620),
-                _ => assert!(false, "Member reference was wrong type!")
+                _ => panic!("Member reference was wrong type!")
             }
             assert_eq!(*role, "inner".to_string());
         },
-        _ => assert!(false, "Member was not expected Member-variant")
+        _ => panic!("Member was not expected Member-variant")
     }
 }
 
@@ -279,11 +279,11 @@ fn way_reference_resolving() {
     let f = File::open("./tests/test_data/way.osm").unwrap();
     let osm = OSM::parse(f).unwrap();
 
-    for node_ref in osm.ways[0].nodes.iter() {
+    for node_ref in osm.ways[&4253174].nodes.iter() {
         match osm.resolve_reference(node_ref) {
             osm::Reference::Node(_) => continue,
-            osm::Reference::Unresolved => assert!(false, "Resolvable way node was not resolved!"),
-            _ => assert!(false, "Valid way references are always Nodes!")
+            osm::Reference::Unresolved => panic!("Resolvable way node was not resolved!"),
+            _ => panic!("Valid way references are always Nodes!")
         }
     }
 }
@@ -293,15 +293,15 @@ fn way_invalid_reference_resolving() {
     let f = File::open("./tests/test_data/way.osm").unwrap();
     let osm = OSM::parse(f).unwrap();
 
-    match osm.resolve_reference(&osm.ways[1].nodes[0]) {
-        osm::Reference::Node(node) => assert_eq!(*node, osm.nodes[0]),
-        osm::Reference::Unresolved => assert!(false, "Resolvable way node was not resolved!"),
-        _ => assert!(false, "Valid way references are always Nodes!")
+    match osm.resolve_reference(&osm.ways[&4253123].nodes[0]) {
+        osm::Reference::Node(node) => assert_eq!(*node, osm.nodes[&1375815878]),
+        osm::Reference::Unresolved => panic!("Resolvable way node was not resolved!"),
+        _ => panic!("Valid way references are always Nodes!")
     }
 
-    match osm.resolve_reference(&osm.ways[1].nodes[1]) {
+    match osm.resolve_reference(&osm.ways[&4253123].nodes[1]) {
         osm::Reference::Unresolved => (),
-        _ => assert!(false, "Unresolvable Node reference was resolved!"),
+        _ => panic!("Unresolvable Node reference was resolved!"),
     }
 }
 
@@ -310,20 +310,20 @@ fn relation_node_reference_resolving() {
     let f = File::open("./tests/test_data/relations.osm").unwrap();
     let osm = OSM::parse(f).unwrap();
 
-    match osm.relations[0].members[0] {
+    match osm.relations[&77994].members[0] {
         osm::Member::Node(ref mref, _) => match osm.resolve_reference(mref) {
-            osm::Reference::Node(node) => assert_eq!(*node, osm.nodes[0]),
-            _ => assert!(false, "Resolvable Relation member was not resolved!")
+            osm::Reference::Node(node) => assert_eq!(*node, osm.nodes[&345579224]),
+            _ => panic!("Resolvable Relation member was not resolved!")
         },
-        _ => assert!(false, "Member should have been Node!")
+        _ => panic!("Member should have been Node!")
     }
 
-    match osm.relations[0].members[1] {
+    match osm.relations[&77994].members[1] {
         osm::Member::Node(ref mref, _) => match osm.resolve_reference(mref) {
-            osm::Reference::Node(node) => assert_eq!(*node, osm.nodes[1]),
-            _ => assert!(false, "Resolvable Relation member was not resolved!")
+            osm::Reference::Node(node) => assert_eq!(*node, osm.nodes[&345579225]),
+            _ => panic!("Resolvable Relation member was not resolved!")
         },
-        _ => assert!(false, "Member should have been Node!")
+        _ => panic!("Member should have been Node!")
     }
 }
 
@@ -332,20 +332,20 @@ fn relation_way_reference_resolving() {
     let f = File::open("./tests/test_data/relations.osm").unwrap();
     let osm = OSM::parse(f).unwrap();
 
-    match osm.relations[1].members[0] {
+    match osm.relations[&1688359].members[0] {
         osm::Member::Way(ref mref, _) => match osm.resolve_reference(mref) {
-            osm::Reference::Way(way) => assert_eq!(*way, osm.ways[0]),
-            _ => assert!(false, "Resolvable Relation member was not resolved!")
+            osm::Reference::Way(way) => assert_eq!(*way, osm.ways[&123365172]),
+            _ => panic!("Resolvable Relation member was not resolved!")
         },
-        _ => assert!(false, "Member should have been Way!")
+        _ => panic!("Member should have been Way!")
     }
 
-    match osm.relations[1].members[1] {
+    match osm.relations[&1688359].members[1] {
         osm::Member::Way(ref mref, _) => match osm.resolve_reference(mref) {
-            osm::Reference::Way(way) => assert_eq!(*way, osm.ways[1]),
-            _ => assert!(false, "Resolvable Relation member was not resolved!")
+            osm::Reference::Way(way) => assert_eq!(*way, osm.ways[&22147620]),
+            _ => panic!("Resolvable Relation member was not resolved!")
         },
-        _ => assert!(false, "Member should have been Way!")
+        _ => panic!("Member should have been Way!")
     }
 }
 
@@ -354,20 +354,20 @@ fn relation_relation_reference_resolving() {
     let f = File::open("./tests/test_data/relations.osm").unwrap();
     let osm = OSM::parse(f).unwrap();
 
-    match osm.relations[4].members[0] {
+    match osm.relations[&155054].members[0] {
         osm::Member::Relation(ref mref, _) => match osm.resolve_reference(mref) {
-            osm::Reference::Relation(rel) => assert_eq!(*rel, osm.relations[2]),
-            _ => assert!(false, "Resolvable Relation member was not resolved!")
+            osm::Reference::Relation(rel) => assert_eq!(*rel, osm.relations[&375952]),
+            _ => panic!("Resolvable Relation member was not resolved!")
         },
-        _ => assert!(false, "Member should have been Relation!")
+        _ => panic!("Member should have been Relation!")
     }
 
-    match osm.relations[4].members[1] {
+    match osm.relations[&155054].members[1] {
         osm::Member::Relation(ref mref, _) => match osm.resolve_reference(mref) {
-            osm::Reference::Relation(rel) => assert_eq!(*rel, osm.relations[3]),
-            _ => assert!(false, "Resolvable Relation member was not resolved!")
+            osm::Reference::Relation(rel) => assert_eq!(*rel, osm.relations[&375951]),
+            _ => panic!("Resolvable Relation member was not resolved!")
         },
-        _ => assert!(false, "Member should have been Relation!")
+        _ => panic!("Member should have been Relation!")
     }
 }
 
@@ -376,28 +376,28 @@ fn relation_with_unresolvable_node() {
     let f = File::open("./tests/test_data/relations.osm").unwrap();
     let osm = OSM::parse(f).unwrap();
 
-    match osm.relations[5].members[0] {
+    match osm.relations[&987654].members[0] {
         osm::Member::Node(ref mref, _) => match osm.resolve_reference(mref) {
             osm::Reference::Unresolved => assert!(true),
-            _ => assert!(false, "Unresolvable reference was resolved")
+            _ => panic!("Unresolvable reference was resolved")
         },
-        _ => assert!(false, "Member should have been Node!")
+        _ => panic!("Member should have been Node!")
     }
 
-    match osm.relations[5].members[1] {
+    match osm.relations[&987654].members[1] {
         osm::Member::Way(ref mref, _) => match osm.resolve_reference(mref) {
             osm::Reference::Unresolved => assert!(true),
-            _ => assert!(false, "Unresolvable reference was resolved")
+            _ => panic!("Unresolvable reference was resolved")
         },
-        _ => assert!(false, "Member should have been Way!")
+        _ => panic!("Member should have been Way!")
     }
 
-    match osm.relations[5].members[2] {
+    match osm.relations[&987654].members[2] {
         osm::Member::Relation(ref mref, _) => match osm.resolve_reference(mref) {
             osm::Reference::Unresolved => assert!(true),
-            _ => assert!(false, "Unresolvable reference was resolved")
+            _ => panic!("Unresolvable reference was resolved")
         },
-        _ => assert!(false, "Member should have been Relation!")
+        _ => panic!("Member should have been Relation!")
     }
 }
 


### PR DESCRIPTION
closes #3

With the changes in this PR, my workload (print the polygons for every building in New York City) went from 2 hours down to 15 seconds.